### PR TITLE
feat: read ~/.config/sway/config.d

### DIFF
--- a/includes.container/etc/sway/config.vanillaos
+++ b/includes.container/etc/sway/config.vanillaos
@@ -219,3 +219,4 @@ bar {
 }
 
 include /etc/sway/config.d/*
+include ~/.config/sway/config.d/*

--- a/includes.container/usr/share/sway/examples/30-keyboard.swayconfig
+++ b/includes.container/usr/share/sway/examples/30-keyboard.swayconfig
@@ -1,0 +1,5 @@
+# keyboard
+input type:keyboard xkb_layout "us,de"
+input type:keyboard xkb_variant "intl,"
+input type:keyboard xkb_options "grp:ctrls_toggle"
+input type:keyboard xkb_capslock disabled

--- a/includes.container/usr/share/sway/examples/31-mouse.swayconfig
+++ b/includes.container/usr/share/sway/examples/31-mouse.swayconfig
@@ -1,0 +1,4 @@
+# MOUSE CONFIG
+input type:mouse left_handed disabled
+input type:mouse natural_scroll disabled
+input type:mouse accel_profile adaptive

--- a/includes.container/usr/share/sway/examples/32-touchpad.swayconfig
+++ b/includes.container/usr/share/sway/examples/32-touchpad.swayconfig
@@ -1,0 +1,15 @@
+# TOUCHPAD CONFIG
+# dwt = disable touchpad while typing
+input type:touchpad dwt enabled
+input type:touchpad tap enabled
+#input type:touchpad click_method button_areas
+input type:touchpad click_method clickfinger
+input type:touchpad tap_button_map lrm
+#input type:touchpad scroll_method edge
+input type:touchpad scroll_method two_finger
+input type:touchpad middle_emulation enabled
+input type:touchpad drag enabled
+input type:touchpad drag_lock enabled
+input type:touchpad events disabled_on_external_mouse enabled
+input type:touchpad natural_scroll enabled
+

--- a/includes.container/usr/share/sway/examples/50-cursor.swayconfig
+++ b/includes.container/usr/share/sway/examples/50-cursor.swayconfig
@@ -1,0 +1,3 @@
+# SEAT CONFIG
+seat * hide_cursor 8000
+#seat * xcursor_theme comix 48


### PR DESCRIPTION
The default sway config reads the directory `~/.config/sway/config.d` at the end so that the user can override default behavior.

This way, the user is able to configure the keyboard, touchpad and mouse.

It is not configurable via Gnome3 settings but its a starting point for customization.

Closes: #8