### PR TITLE
Feat: systemd integration

### DIFF
--- a/includes.container/etc/sway/config.d/51-systemd-sway-session.conf
+++ b/includes.container/etc/sway/config.d/51-systemd-sway-session.conf
@@ -1,0 +1,6 @@
+# Systemd-integration: sway-session
+# https://github.com/swaywm/sway/wiki/Systemd-integration
+# Note that this file should be executed after `50-systemd-user.conf`,
+# which is created by the sway DEB archive.
+exec systemctl --user start sway-session.target
+exec swaymsg -t subscribe '["shutdown"]' && systemctl --user stop sway-session.target

--- a/includes.container/usr/lib/systemd/user/sway-session.target
+++ b/includes.container/usr/lib/systemd/user/sway-session.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=sway compositor session
+Documentation=man:systemd.special(7)
+BindsTo=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target

--- a/includes.container/wayland-sessions/sway.desktop
+++ b/includes.container/wayland-sessions/sway.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Sway
+Comment=An i3-compatible Wayland compositor
+Exec=/usr/bin/systemd-cat --identifier=sway /usr/bin/sway
+Type=Application
+DesktopNames=sway

--- a/recipe.yml
+++ b/recipe.yml
@@ -42,6 +42,13 @@ stages:
     - cp -av /etc/sway/config.vanillaos /etc/sway/config
     - echo Sway configuration updated for Vanilla-OS
 
+  - name: sway-session-overwrite
+    type: shell
+    commands:
+    - cp -av /wayland-sessions/sway.desktop /usr/share/wayland-sessions/sway.desktop
+    - rm -rv /wayland-sessions
+    - echo Sway session updated for Vanilla-OS
+
   # Put your custom actions before this comment
 
   - name: set-image-name-abroot


### PR DESCRIPTION
Follow the sway guide for systemd integration:
https://github.com/swaywm/sway/wiki/Systemd-integration

 - Managing user applications with systemd
 - Sway logging and journalctl

Sway's output should be printable via:
```
journalctl --user --identifier sway
```