### PR TITLE
feat: replace swaynag message with wlogout

### DIFF
--- a/includes.container/etc/sway/config.vanillaos
+++ b/includes.container/etc/sway/config.vanillaos
@@ -73,7 +73,7 @@ output * bg /usr/share/backgrounds/vanilla/petals_light.webp stretch
     bindsym $mod+Shift+c reload
 
     # Exit sway (logs you out of your Wayland session)
-    bindsym $mod+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -B 'Yes, exit sway' 'swaymsg exit'
+    bindsym $mod+Shift+e exec wlogout
 #
 # Moving around:
 #

--- a/recipe.yml
+++ b/recipe.yml
@@ -35,6 +35,7 @@ stages:
       - fonts-font-awesome
       - fuzzel
       - pulseaudio-utils # pactl
+      - wlogout
 
   - name: sway-config-overwrite
     type: shell


### PR DESCRIPTION
The swaynag message `You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.` can only logout but not shutdown or reboot. Moreover, by default, it works only with a mouse.

Thus, let us replace it with the program `wlogout`. The latest version (v1.2.2) will currently be installed.

Link: https://github.com/ArtsyMacaw/wlogout