### PR TITLE
fix: font icons in waybar default config

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -38,11 +38,26 @@ stages:
       - swayimg
       - swayidle
       - swaylock
-      - fonts-font-awesome
       - fuzzel
       - pulseaudio-utils # pactl
       - wlogout
       - waybar # installs and enables waybar.service
+      - fontconfig
+
+  # NOTE: Waybar default config needs Font Awesome and Meslo LG.
+  - name: nerd-fonts-for-waybar
+    type: shell
+    commands:
+      - mkdir -p /usr/share/fonts
+      - wget -qO- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Meslo.tar.xz | tar xvJ -C /usr/share/fonts
+      - fc-cache -fv
+
+  - name: more-fonts-for-waybar
+    type: apt
+    source:
+      packages:
+      - fonts-font-awesome
+      - fonts-material-design-icons-iconfont
 
   - name: sway-config-overwrite
     type: shell


### PR DESCRIPTION
The brightness module icons was not shown.

The reason was that the Meslo LG font was missing. But there is no DEB archive available yet.

Furthermore, the Material font is installed, too.