### PR TITLE
Feat: use sway-notification-center (swaync) as notification daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
  * app launcher: [Fuzzel](https://codeberg.org/dnkl/fuzzel)
  * bar: [Waybar](https://github.com/Alexays/Waybar)
  * logout menu: [wlogout](https://github.com/ArtsyMacaw/wlogout)
- * notification daemon: [mako](https://github.com/emersion/mako)
+ * notifications: [SwayNotificationCenter](https://github.com/ErikReider/SwayNotificationCenter)
  * brightness control with XF86MonBrightnessUp/Down keys: [blight](https://github.com/voltaireNoir/blight) 0.7.1
  * based on Vanilla OS Desktop image (Gnome3 desktop)
 
@@ -30,7 +30,7 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
 
  * sway's output handled by journald: `journalctl --user --identifier sway`
  * `waybar.service`
- * `mako.service`
+ * `swaync.service`
  * `sway-session.target`
  * `swayidle.service`
  * `swaylock.service`

--- a/recipe.yml
+++ b/recipe.yml
@@ -51,6 +51,7 @@ stages:
     commands:
       - mkdir -p /usr/share/fonts
       - wget -qO- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Meslo.tar.xz | tar xvJ -C /usr/share/fonts
+      - wget -qO- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Noto.tar.xz | tar xvJ -C /usr/share/fonts
       - fc-cache -fv
 
   - name: more-fonts

--- a/recipe.yml
+++ b/recipe.yml
@@ -42,11 +42,10 @@ stages:
       - pulseaudio-utils # pactl
       - wlogout
       - waybar # installs and enables waybar.service
-      - mako-notifier # installs and enables mako.service
+      - sway-notification-center # installs and enables swaync.service
       - fontconfig
 
   # NOTE: Waybar default config needs Font Awesome and Meslo LG.
-  #       Mako supports emojis.
   - name: nerd-fonts
     type: shell
     commands:


### PR DESCRIPTION
swaync seems to provide more features than mako. Especially, grouping notifications are welcome. 