### PR TITLE
Feat: Print Screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Containerfile
 downloads/
 plugins/
 sources/
+# log files
+*.log

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
    - [slurp](https://github.com/emersion/slurp) to select an area on the screen
    - [swappy](https://github.com/jtheoof/swappy) to edit the captured screenshot
    - [xdg-utils](https://www.freedesktop.org/wiki/Software/xdg-utils/) to open the captured screenshot with the default image viewer
+   - [dragon-drop](https://github.com/mwh/dragon) to drag and drop the captured screenshot
    - [wl-clipboard](https://github.com/bugaevc/wl-clipboard) to copy the screenshot to the clipboard
    - [wf-recorder](https://github.com/ammen99/wf-recorder) to capture videos
  * screenshot/video capture with Print key: [sway-interactive-screenshot](https://github.com/moverest/sway-interactive-screenshot)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
  * logout menu: [wlogout](https://github.com/ArtsyMacaw/wlogout)
  * notifications: [SwayNotificationCenter](https://github.com/ErikReider/SwayNotificationCenter)
  * [XDG Desktop Portal](https://github.com/flatpak/xdg-desktop-portal) backend: [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr)
+   - [grim](https://sr.ht/~emersion/grim/) to take the screenshot
+   - [slurp](https://github.com/emersion/slurp) to select an area on the screen
+   - [swappy](https://github.com/jtheoof/swappy) to edit the captured screenshot
+   - [wl-clipboard](https://github.com/bugaevc/wl-clipboard) to copy the screenshot to the clipboard
+   - [wf-recorder](https://github.com/ammen99/wf-recorder) to capture videos
  * brightness control with XF86MonBrightnessUp/Down keys: [blight](https://github.com/voltaireNoir/blight) 0.7.1
  * based on Vanilla OS Desktop image (Gnome3 desktop)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
    - [grim](https://sr.ht/~emersion/grim/) to take the screenshot
    - [slurp](https://github.com/emersion/slurp) to select an area on the screen
    - [swappy](https://github.com/jtheoof/swappy) to edit the captured screenshot
+   - [xdg-utils](https://www.freedesktop.org/wiki/Software/xdg-utils/) to open the captured screenshot with the default image viewer
    - [wl-clipboard](https://github.com/bugaevc/wl-clipboard) to copy the screenshot to the clipboard
    - [wf-recorder](https://github.com/ammen99/wf-recorder) to capture videos
  * screenshot/video capture with Print key: [sway-interactive-screenshot](https://github.com/moverest/sway-interactive-screenshot)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
  * bar: [Waybar](https://github.com/Alexays/Waybar)
  * logout menu: [wlogout](https://github.com/ArtsyMacaw/wlogout)
  * notifications: [SwayNotificationCenter](https://github.com/ErikReider/SwayNotificationCenter)
- * [XDG Desktop Portal](https://github.com/flatpak/xdg-desktop-portal) backend: [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr)
+ * print screen / video capture with Print key: [sway-interactive-screenshot](https://github.com/moverest/sway-interactive-screenshot)
+   - [XDG Desktop Portal](https://github.com/flatpak/xdg-desktop-portal) backend: [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr)
    - [grim](https://sr.ht/~emersion/grim/) to take the screenshot
    - [slurp](https://github.com/emersion/slurp) to select an area on the screen
    - [swappy](https://github.com/jtheoof/swappy) to edit the captured screenshot
@@ -31,7 +32,6 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
    - [dragon-drop](https://github.com/mwh/dragon) to drag and drop the captured screenshot
    - [wl-clipboard](https://github.com/bugaevc/wl-clipboard) to copy the screenshot to the clipboard
    - [wf-recorder](https://github.com/ammen99/wf-recorder) to capture videos
- * screenshot/video capture with Print key: [sway-interactive-screenshot](https://github.com/moverest/sway-interactive-screenshot)
  * brightness control with XF86MonBrightnessUp/Down keys: [blight](https://github.com/voltaireNoir/blight) 0.7.1
  * based on Vanilla OS Desktop image (Gnome3 desktop)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
  * bar: [Waybar](https://github.com/Alexays/Waybar)
  * logout menu: [wlogout](https://github.com/ArtsyMacaw/wlogout)
  * notifications: [SwayNotificationCenter](https://github.com/ErikReider/SwayNotificationCenter)
+ * [XDG Desktop Portal](https://github.com/flatpak/xdg-desktop-portal) backend: [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr)
  * brightness control with XF86MonBrightnessUp/Down keys: [blight](https://github.com/voltaireNoir/blight) 0.7.1
  * based on Vanilla OS Desktop image (Gnome3 desktop)
 
@@ -31,6 +32,8 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
  * sway's output handled by journald: `journalctl --user --identifier sway`
  * `waybar.service`
  * `swaync.service`
+ * `xdg-desktop-portal.service`
+ * `xdg-desktop-portal-wlr.service`
  * `sway-session.target`
  * `swayidle.service`
  * `swaylock.service`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ We want to provide a similar experiance as the [Manjaro Sway Edition](https://gi
    - [swappy](https://github.com/jtheoof/swappy) to edit the captured screenshot
    - [wl-clipboard](https://github.com/bugaevc/wl-clipboard) to copy the screenshot to the clipboard
    - [wf-recorder](https://github.com/ammen99/wf-recorder) to capture videos
+ * screenshot/video capture with Print key: [sway-interactive-screenshot](https://github.com/moverest/sway-interactive-screenshot)
  * brightness control with XF86MonBrightnessUp/Down keys: [blight](https://github.com/voltaireNoir/blight) 0.7.1
  * based on Vanilla OS Desktop image (Gnome3 desktop)
 

--- a/build-in-vanillaos.sh
+++ b/build-in-vanillaos.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eux
+vib build recipe.yml
+host-shell podman image build -t vanillaos/desktop-sway . $* | tee podman.log

--- a/includes.container/etc/sway/config.d/52-xdg-current-desktop.conf
+++ b/includes.container/etc/sway/config.d/52-xdg-current-desktop.conf
@@ -1,0 +1,2 @@
+# xdg-desktop-portal-wlr requirements
+exec dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP=sway

--- a/includes.container/etc/sway/config.d/85-print.config
+++ b/includes.container/etc/sway/config.d/85-print.config
@@ -1,0 +1,3 @@
+# sway-interactive-screenshot is a helper script that enables users to take screenshots and video captures interactively with Sway.
+bindsym Print exec /usr/bin/sway-interactive-screenshot
+bindsym Shift+Print exec /usr/bin/sway-interactive-screenshot --video

--- a/recipe.yml
+++ b/recipe.yml
@@ -132,6 +132,24 @@ stages:
     - cp -av -t /usr/share/doc/sway-interactive-screenshot-${VERSION} /tmp/sway-interactive-screenshot/LICENSE
     - rm -r /tmp/sway-interactive-screenshot
 
+  - name: dragon-drop-compile
+    type: shell
+    commands:
+    - set -ux
+    - apt-get install -y --mark-auto make gcc libgtk-3-dev # will be removed in cleanup
+    - gcc --version
+    - 'VERSION=$(curl -s https://api.github.com/repos/mwh/dragon/releases/latest | grep "tag_name" | cut -d : -f 2,3 | tr -d \ \",v)'
+    - mkdir -p /tmp/dragon-drop
+    - cd /tmp/dragon-drop
+    - wget --quiet --output-document=- https://github.com/mwh/dragon/archive/refs/tags/v${VERSION}.tar.gz | tar xvz --strip-components=1
+    - make all
+    - make PREFIX=/usr NAME=dragon-drop install
+    - ln -s dragon-drop /usr/bin/dragon
+    - mkdir -p /usr/share/doc/dragon-drop-${VERSION}
+    - cp -av -t /usr/share/doc/dragon-drop-${VERSION} README
+    - cp -av -t /usr/share/doc/dragon-drop-${VERSION} LICENCE
+    - cd && rm -r /tmp/dragon-drop
+
   # Put your custom actions before this comment
 
   - name: set-image-name-abroot

--- a/recipe.yml
+++ b/recipe.yml
@@ -50,6 +50,7 @@ stages:
       - swappy
       - wl-clipboard
       - wf-recorder
+      - xdg-utils
       - fontconfig
 
   # NOTE: Waybar default config needs Font Awesome and Meslo LG.

--- a/recipe.yml
+++ b/recipe.yml
@@ -57,8 +57,8 @@ stages:
     type: shell
     commands:
       - mkdir -p /usr/share/fonts
-      - wget -qO- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Meslo.tar.xz | tar xvJ -C /usr/share/fonts
-      - wget -qO- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Noto.tar.xz | tar xvJ -C /usr/share/fonts
+      - wget --quiet --output-document=- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Meslo.tar.xz | tar xvJ -C /usr/share/fonts
+      - wget --quiet --output-document=- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Noto.tar.xz | tar xvJ -C /usr/share/fonts
       - fc-cache -fv
 
   - name: more-fonts
@@ -111,6 +111,20 @@ stages:
     - chgrp --changes video /usr/bin/blight
     - chmod --changes g+s /usr/bin/blight
     - ls -l /usr/bin/blight
+
+  - name: sway-interactive-screenshot
+    type: shell
+    commands:
+    - set -ux
+    - 'VERSION=$(curl -s https://api.github.com/repos/moverest/sway-interactive-screenshot/releases/latest | grep "tag_name" | cut -d : -f 2,3 | tr -d \ \",)'
+    - mkdir -p /tmp/sway-interactive-screenshot
+    - wget --quiet --output-document=- https://github.com/moverest/sway-interactive-screenshot/archive/refs/tags/${VERSION}.tar.gz | tar xvz --strip-components=1 -C /tmp/sway-interactive-screenshot
+    - cp -av /tmp/sway-interactive-screenshot/sway-interactive-screenshot /usr/bin
+    - chmod 0755 /usr/bin/sway-interactive-screenshot
+    - mkdir -p /usr/share/doc/sway-interactive-screenshot-${VERSION}
+    - cp -av -t /usr/share/doc/sway-interactive-screenshot-${VERSION} /tmp/sway-interactive-screenshot/README.md
+    - cp -av -t /usr/share/doc/sway-interactive-screenshot-${VERSION} /tmp/sway-interactive-screenshot/LICENSE
+    - rm -r /tmp/sway-interactive-screenshot
 
   # Put your custom actions before this comment
 

--- a/recipe.yml
+++ b/recipe.yml
@@ -27,6 +27,7 @@ stages:
     type: apt
     source:
       packages:
+      - tree
       - vim
 
   - name: sway-packages
@@ -43,6 +44,7 @@ stages:
       - wlogout
       - waybar # installs and enables waybar.service
       - sway-notification-center # installs and enables swaync.service
+      - xdg-desktop-portal-wlr
       - fontconfig
 
   # NOTE: Waybar default config needs Font Awesome and Meslo LG.

--- a/recipe.yml
+++ b/recipe.yml
@@ -56,6 +56,7 @@ stages:
   - name: nerd-fonts
     type: shell
     commands:
+    - set -ux
     - mkdir -p /usr/share/fonts
     - wget --quiet --output-document=- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Meslo.tar.xz | tar xvJ -C /usr/share/fonts
     - wget --quiet --output-document=- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Noto.tar.xz | tar xvJ -C /usr/share/fonts
@@ -72,6 +73,7 @@ stages:
   - name: sway-config-overwrite
     type: shell
     commands:
+    - set -ux
     - cp -av /etc/sway/config /etc/sway/config.orig
     - cp -av /etc/sway/config.vanillaos /etc/sway/config
     - echo Sway configuration updated for Vanilla-OS
@@ -79,6 +81,7 @@ stages:
   - name: sway-session-overwrite
     type: shell
     commands:
+    - set -ux
     - cp -av /wayland-sessions/sway.desktop /usr/share/wayland-sessions/sway.desktop
     - rm -rv /wayland-sessions
     - echo Sway session updated for Vanilla-OS
@@ -91,6 +94,7 @@ stages:
   - name: swaylock-fix
     type: shell
     commands:
+    - set -ux
     - ls -l /sbin/unix_chkpwd /etc/shadow
     # ```console
     # -rwxr-sr-x 1 root shadow /sbin/unix_chkpwd
@@ -106,6 +110,7 @@ stages:
   - name: blight-setup
     type: shell
     commands:
+    - set -ux
     - /usr/bin/blight setup
     - ls -l /usr/bin/blight
     - chgrp --changes video /usr/bin/blight

--- a/recipe.yml
+++ b/recipe.yml
@@ -56,10 +56,10 @@ stages:
   - name: nerd-fonts
     type: shell
     commands:
-      - mkdir -p /usr/share/fonts
-      - wget --quiet --output-document=- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Meslo.tar.xz | tar xvJ -C /usr/share/fonts
-      - wget --quiet --output-document=- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Noto.tar.xz | tar xvJ -C /usr/share/fonts
-      - fc-cache -fv
+    - mkdir -p /usr/share/fonts
+    - wget --quiet --output-document=- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Meslo.tar.xz | tar xvJ -C /usr/share/fonts
+    - wget --quiet --output-document=- https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Noto.tar.xz | tar xvJ -C /usr/share/fonts
+    - fc-cache -fv
 
   - name: more-fonts
     type: apt

--- a/recipe.yml
+++ b/recipe.yml
@@ -45,6 +45,11 @@ stages:
       - waybar # installs and enables waybar.service
       - sway-notification-center # installs and enables swaync.service
       - xdg-desktop-portal-wlr
+      - grim
+      - slurp
+      - swappy
+      - wl-clipboard
+      - wf-recorder
       - fontconfig
 
   # NOTE: Waybar default config needs Font Awesome and Meslo LG.


### PR DESCRIPTION
Sway provides `[Print]` key to take a screenshot and `[Shift+Print]` keys to capture videos.

Theses keys start [`sway-interactive-screenshot`](https://github.com/moverest/sway-interactive-screenshot).

The following tools are used by `sway-interactive-screenshot` or are recommended:
   - [XDG Desktop Portal](https://github.com/flatpak/xdg-desktop-portal) backend: [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr)
   - [grim](https://sr.ht/~emersion/grim/) to take the screenshot
   - [slurp](https://github.com/emersion/slurp) to select an area on the screen
   - [swappy](https://github.com/jtheoof/swappy) to edit the captured screenshot
   - [xdg-utils](https://www.freedesktop.org/wiki/Software/xdg-utils/) to open the captured screenshot with the default image viewer
   - [dragon-drop](https://github.com/mwh/dragon) to drag and drop the captured screenshot
   - [wl-clipboard](https://github.com/bugaevc/wl-clipboard) to copy the screenshot to the clipboard
   - [wf-recorder](https://github.com/ammen99/wf-recorder) to capture videos

Additionally, `OBS Studio` was installed as Flatpack via `Software` and seems to work, too.